### PR TITLE
Add Metric monitoring and Caching AOP aspects

### DIFF
--- a/account_processing/pom.xml
+++ b/account_processing/pom.xml
@@ -13,4 +13,11 @@
         <maven.compiler.target>22</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+    <dependencies> <dependency>
+        <groupId>ru.t1hwork</groupId>
+        <artifactId>aop_annotations</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+        <!--<scope>system</scope>
+        <systemPath>${project.basedir}/../aop_annotations/target/aop_annotations-0.0.1-SNAPSHOT.jar</systemPath>-->
+    </dependency></dependencies>
 </project>

--- a/account_processing/src/main/java/org/accountpr/demo/AccountProcMain.java
+++ b/account_processing/src/main/java/org/accountpr/demo/AccountProcMain.java
@@ -3,9 +3,17 @@ package org.accountpr.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
+//@SpringBootApplication
+//@EnableScheduling
+//@SpringBootApplication
+
+@SpringBootApplication(scanBasePackages = {"org.accountpr.demo", "org.aop"})
+@EntityScan(basePackages = {"org.accountpr.demo", "org.aop.model"})
+@EnableJpaRepositories(basePackages = {"org.accountpr.demo", "org.aop.repository"})
 @EnableScheduling
 public class AccountProcMain {
     public static void main(String[] args) {

--- a/account_processing/src/main/java/org/accountpr/demo/controller/AccountController.java
+++ b/account_processing/src/main/java/org/accountpr/demo/controller/AccountController.java
@@ -4,6 +4,7 @@ import org.accountpr.demo.model.dto.AccountDTO;
 import org.accountpr.demo.service.AccountService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.aop.annotations.HttpIncomeRequestLog;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,27 +19,32 @@ public class AccountController {
     private final AccountService accountService;
 
     @PostMapping
+    @HttpIncomeRequestLog
     public ResponseEntity<AccountDTO> createAccount(@Valid @RequestBody AccountDTO dto) {
         AccountDTO created = accountService.createAccount(dto);
         return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 
     @GetMapping
+  @HttpIncomeRequestLog
     public ResponseEntity<List<AccountDTO>> getAllAccounts() {
         return ResponseEntity.ok(accountService.getAllAccounts());
     }
 
     @GetMapping("/{id}")
+  @HttpIncomeRequestLog
     public ResponseEntity<AccountDTO> getAccountById(@PathVariable Long id) {
         return ResponseEntity.ok(accountService.getAccountById(id));
     }
 
     @GetMapping("/client/{clientId}")
+  @HttpIncomeRequestLog
     public ResponseEntity<List<AccountDTO>> getAccountsByClientId(@PathVariable Long clientId) {
         return ResponseEntity.ok(accountService.getAccountsByClientId(clientId));
     }
 
     @PutMapping("/{id}")
+  @HttpIncomeRequestLog
     public ResponseEntity<AccountDTO> updateAccount(
             @PathVariable Long id,
             @Valid @RequestBody AccountDTO dto
@@ -47,6 +53,7 @@ public class AccountController {
     }
 
     @DeleteMapping("/{id}")
+  @HttpIncomeRequestLog
     public ResponseEntity<Void> deleteAccount(@PathVariable Long id) {
         accountService.deleteAccount(id);
         return ResponseEntity.noContent().build();

--- a/account_processing/src/main/java/org/accountpr/demo/controller/CardController.java
+++ b/account_processing/src/main/java/org/accountpr/demo/controller/CardController.java
@@ -4,6 +4,7 @@ import org.accountpr.demo.model.dto.CardDTO;
 import org.accountpr.demo.service.CardService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.aop.annotations.HttpIncomeRequestLog;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,36 +19,43 @@ public class CardController {
     private final CardService cardService;
 
     @PostMapping
+    @HttpIncomeRequestLog
     public ResponseEntity<CardDTO> createCard(@Valid @RequestBody CardDTO dto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(cardService.createCard(dto));
     }
 
     @GetMapping
+    @HttpIncomeRequestLog
     public ResponseEntity<List<CardDTO>> getAllCards() {
         return ResponseEntity.ok(cardService.getAllCards());
     }
 
     @GetMapping("/{id}")
+    @HttpIncomeRequestLog
     public ResponseEntity<CardDTO> getCardById(@PathVariable Long id) {
         return ResponseEntity.ok(cardService.getCardById(id));
     }
 
     @GetMapping("/cardId/{cardId}")
+    @HttpIncomeRequestLog
     public ResponseEntity<CardDTO> getCardByCardId(@PathVariable String cardId) {
         return ResponseEntity.ok(cardService.getCardByCardId(cardId));
     }
 
     @GetMapping("/account/{accountId}")
+    @HttpIncomeRequestLog
     public ResponseEntity<List<CardDTO>> getCardsByAccountId(@PathVariable Long accountId) {
         return ResponseEntity.ok(cardService.getCardsByAccountId(accountId));
     }
 
     @PutMapping("/{id}")
+    @HttpIncomeRequestLog
     public ResponseEntity<CardDTO> updateCard(@PathVariable Long id, @Valid @RequestBody CardDTO dto) {
         return ResponseEntity.ok(cardService.updateCard(id, dto));
     }
 
     @DeleteMapping("/{id}")
+    @HttpIncomeRequestLog
     public ResponseEntity<Void> deleteCard(@PathVariable Long id) {
         cardService.deleteCard(id);
         return ResponseEntity.noContent().build();

--- a/account_processing/src/main/java/org/accountpr/demo/controller/PaymentController.java
+++ b/account_processing/src/main/java/org/accountpr/demo/controller/PaymentController.java
@@ -5,6 +5,7 @@ import org.accountpr.demo.model.enums.PaymentType;
 import org.accountpr.demo.service.PaymentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.aop.annotations.HttpIncomeRequestLog;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,6 +20,7 @@ public class PaymentController {
     private final PaymentService paymentService;
 
     @PostMapping
+    @HttpIncomeRequestLog
     public ResponseEntity<PaymentDTO> createPayment(@Valid @RequestBody PaymentDTO dto) {
         return ResponseEntity.status(HttpStatus.CREATED).body(paymentService.createPayment(dto));
     }
@@ -29,31 +31,37 @@ public class PaymentController {
     }
 
     @GetMapping("/{id}")
+    @HttpIncomeRequestLog
     public ResponseEntity<PaymentDTO> getPaymentById(@PathVariable Long id) {
         return ResponseEntity.ok(paymentService.getPaymentById(id));
     }
 
     @GetMapping("/account/{accountId}")
+    @HttpIncomeRequestLog
     public ResponseEntity<List<PaymentDTO>> getPaymentsByAccountId(@PathVariable Long accountId) {
         return ResponseEntity.ok(paymentService.getPaymentsByAccountId(accountId));
     }
 
     @GetMapping("/type/{type}")
+    @HttpIncomeRequestLog
     public ResponseEntity<List<PaymentDTO>> getPaymentsByType(@PathVariable PaymentType type) {
         return ResponseEntity.ok(paymentService.getPaymentsByType(type));
     }
 
     @GetMapping("/credit/{isCredit}")
+    @HttpIncomeRequestLog
     public ResponseEntity<List<PaymentDTO>> getPaymentsByIsCredit(@PathVariable Boolean isCredit) {
         return ResponseEntity.ok(paymentService.getPaymentsByIsCredit(isCredit));
     }
 
     @PutMapping("/{id}")
+    @HttpIncomeRequestLog
     public ResponseEntity<PaymentDTO> updatePayment(@PathVariable Long id, @Valid @RequestBody PaymentDTO dto) {
         return ResponseEntity.ok(paymentService.updatePayment(id, dto));
     }
 
     @DeleteMapping("/{id}")
+    @HttpIncomeRequestLog
     public ResponseEntity<Void> deletePayment(@PathVariable Long id) {
         paymentService.deletePayment(id);
         return ResponseEntity.noContent().build();

--- a/account_processing/src/main/java/org/accountpr/demo/controller/TransactionController.java
+++ b/account_processing/src/main/java/org/accountpr/demo/controller/TransactionController.java
@@ -6,6 +6,7 @@ import org.accountpr.demo.model.enums.TransactionType;
 import org.accountpr.demo.service.TransactionService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.aop.annotations.HttpIncomeRequestLog;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.kafka.core.KafkaTemplate;
@@ -23,6 +24,7 @@ public class TransactionController {
     private final TransactionService transactionService;
     private final KafkaTemplate<String, Object> kafkaTemplate;
     @PostMapping
+    @HttpIncomeRequestLog
     public ResponseEntity<TransactionDTO> createTransaction(@Valid @RequestBody TransactionDTO dto) {
         TransactionDTO createdTransaction = transactionService.createTransaction(dto);
         kafkaTemplate.send("client_transactions",
@@ -41,41 +43,49 @@ public class TransactionController {
         return message;
     }
     @GetMapping
+    @HttpIncomeRequestLog
     public ResponseEntity<List<TransactionDTO>> getAllTransactions() {
         return ResponseEntity.ok(transactionService.getAllTransactions());
     }
 
     @GetMapping("/{id}")
+    @HttpIncomeRequestLog
     public ResponseEntity<TransactionDTO> getTransactionById(@PathVariable Long id) {
         return ResponseEntity.ok(transactionService.getTransactionById(id));
     }
 
     @GetMapping("/account/{accountId}")
+    @HttpIncomeRequestLog
     public ResponseEntity<List<TransactionDTO>> getTransactionsByAccountId(@PathVariable Long accountId) {
         return ResponseEntity.ok(transactionService.getTransactionsByAccountId(accountId));
     }
 
     @GetMapping("/card/{cardId}")
+    @HttpIncomeRequestLog
     public ResponseEntity<List<TransactionDTO>> getTransactionsByCardId(@PathVariable Long cardId) {
         return ResponseEntity.ok(transactionService.getTransactionsByCardId(cardId));
     }
 
     @GetMapping("/type/{type}")
+    @HttpIncomeRequestLog
     public ResponseEntity<List<TransactionDTO>> getTransactionsByType(@PathVariable TransactionType type) {
         return ResponseEntity.ok(transactionService.getTransactionsByType(type));
     }
 
     @GetMapping("/status/{status}")
+    @HttpIncomeRequestLog
     public ResponseEntity<List<TransactionDTO>> getTransactionsByStatus(@PathVariable TransactionStatus status) {
         return ResponseEntity.ok(transactionService.getTransactionsByStatus(status));
     }
 
     @PutMapping("/{id}")
+    @HttpIncomeRequestLog
     public ResponseEntity<TransactionDTO> updateTransaction(@PathVariable Long id, @Valid @RequestBody TransactionDTO dto) {
         return ResponseEntity.ok(transactionService.updateTransaction(id, dto));
     }
 
     @DeleteMapping("/{id}")
+    @HttpIncomeRequestLog
     public ResponseEntity<Void> deleteTransaction(@PathVariable Long id) {
         transactionService.deleteTransaction(id);
         return ResponseEntity.noContent().build();

--- a/account_processing/src/main/java/org/accountpr/demo/repository/AccountRepository.java
+++ b/account_processing/src/main/java/org/accountpr/demo/repository/AccountRepository.java
@@ -1,10 +1,12 @@
 package org.accountpr.demo.repository;
 
 import org.accountpr.demo.model.Account;
+import org.aop.annotations.Cached;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface AccountRepository extends JpaRepository<Account, Long> {
+    @Cached
     List<Account> findByClientId(Long ClientId);
 }

--- a/account_processing/src/main/java/org/accountpr/demo/service/AccountService.java
+++ b/account_processing/src/main/java/org/accountpr/demo/service/AccountService.java
@@ -7,6 +7,7 @@ import org.accountpr.demo.model.dto.AccountDTO;
 import org.accountpr.demo.model.enums.AccountStatus;
 import org.accountpr.demo.repository.AccountRepository;
 import org.aop.annotations.LogDatasourceError;
+import org.aop.annotations.Metric;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -22,6 +23,7 @@ public class AccountService {
     private final AccountRepository accountRepository;
 
     @LogDatasourceError(type="ERROR")
+    @Metric
     public AccountDTO createAccount(AccountDTO dto) {
         Account account = Account.builder(
                         dto.getClientId(),
@@ -36,7 +38,7 @@ public class AccountService {
         Account saved = accountRepository.save(account);
         return convertToDTO(saved);
     }
-
+@Metric
     public List<AccountDTO> getAllAccounts() {
         return accountRepository.findAll()
                 .stream()
@@ -49,7 +51,7 @@ public class AccountService {
                 .map(this::convertToDTO)
                 .orElseThrow(() -> new IllegalArgumentException("Account not found with id: " + id));
     }
-
+    @Metric(name="accounts.search.byClientId")
     public List<AccountDTO> getAccountsByClientId(Long clientId) {
         return accountRepository.findByClientId(clientId)
                 .stream()

--- a/account_processing/src/main/java/org/accountpr/demo/service/AccountService.java
+++ b/account_processing/src/main/java/org/accountpr/demo/service/AccountService.java
@@ -6,6 +6,7 @@ import org.accountpr.demo.model.Account;
 import org.accountpr.demo.model.dto.AccountDTO;
 import org.accountpr.demo.model.enums.AccountStatus;
 import org.accountpr.demo.repository.AccountRepository;
+import org.aop.annotations.LogDatasourceError;
 import org.springframework.stereotype.Service;
 
 import java.math.BigDecimal;
@@ -20,6 +21,7 @@ public class AccountService {
 
     private final AccountRepository accountRepository;
 
+    @LogDatasourceError(type="ERROR")
     public AccountDTO createAccount(AccountDTO dto) {
         Account account = Account.builder(
                         dto.getClientId(),
@@ -54,7 +56,7 @@ public class AccountService {
                 .map(this::convertToDTO)
                 .collect(Collectors.toList());
     }
-
+    @LogDatasourceError(type="ERROR")
     public AccountDTO updateAccount(Long id, AccountDTO dto) {
         Account existing = accountRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Account not found with id: " + id));
@@ -70,7 +72,7 @@ public class AccountService {
         Account updated = accountRepository.save(existing);
         return convertToDTO(updated);
     }
-
+    @LogDatasourceError(type="WARN")
     public void deleteAccount(Long id) {
         if (!accountRepository.existsById(id)) {
             throw new IllegalArgumentException("Account not found with id: " + id);

--- a/account_processing/src/main/java/org/accountpr/demo/service/CardService.java
+++ b/account_processing/src/main/java/org/accountpr/demo/service/CardService.java
@@ -6,6 +6,7 @@ import org.accountpr.demo.model.enums.CardStatus;
 import org.accountpr.demo.model.enums.PaymentSystem;
 import org.accountpr.demo.repository.CardRepository;
 import lombok.RequiredArgsConstructor;
+import org.aop.annotations.LogDatasourceError;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,7 +20,7 @@ import java.util.stream.Collectors;
 public class CardService {
 
     private final CardRepository cardRepository;
-
+    @LogDatasourceError(type="ERROR")
     public CardDTO createCard(CardDTO dto) {
         if (cardRepository.existsByCardId(dto.getCardId())) {
             throw new IllegalArgumentException("Card with this cardId already exists: " + dto.getCardId());
@@ -60,6 +61,7 @@ public class CardService {
                 .collect(Collectors.toList());
     }
 
+    @LogDatasourceError(type="ERROR")
     public CardDTO updateCard(Long id, CardDTO dto) {
         Card card = cardRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Card not found with id: " + id));
@@ -78,6 +80,7 @@ public class CardService {
         return convertToDTO(updated);
     }
 
+    @LogDatasourceError(type="WARN")
     public void deleteCard(Long id) {
         if (!cardRepository.existsById(id)) {
             throw new IllegalArgumentException("Card not found with id: " + id);

--- a/account_processing/src/main/java/org/accountpr/demo/service/ClientProductConsumerService.java
+++ b/account_processing/src/main/java/org/accountpr/demo/service/ClientProductConsumerService.java
@@ -9,6 +9,7 @@ import org.accountpr.demo.model.dto.CardDTO;
 import org.accountpr.demo.model.dto.PaymentDTO;
 import org.accountpr.demo.model.dto.TransactionDTO;
 import org.accountpr.demo.model.enums.*;
+import org.aop.annotations.LogDatasourceError;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Service;
 
@@ -28,6 +29,7 @@ public class ClientProductConsumerService {
     private final TransactionMonitoringService monitoringService;
     private final CreditPaymentService creditPaymentService;
     @KafkaListener(topics = "client_products", groupId = "account-service")
+    @LogDatasourceError(type="ERROR")
     public void consumeClientProductMessage(Map<String, Object> message){
         log.info("Received client product message: {}", message);
         try {
@@ -104,6 +106,7 @@ public class ClientProductConsumerService {
             log.error("Error processing transaction: {}", e.getMessage(), e);
         }
     }
+    @LogDatasourceError(type="ERROR")
     private void updateTransactionStatus(Long transactionId, TransactionStatus status) {
         try {
             TransactionDTO existingTransaction = transactionService.getTransactionById(transactionId);

--- a/account_processing/src/main/java/org/accountpr/demo/service/CreditPaymentService.java
+++ b/account_processing/src/main/java/org/accountpr/demo/service/CreditPaymentService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.accountpr.demo.model.dto.AccountDTO;
 import org.accountpr.demo.model.dto.PaymentDTO;
 import org.accountpr.demo.model.enums.PaymentType;
+import org.aop.annotations.LogDatasourceError;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +26,7 @@ public class CreditPaymentService {
     private final TransactionService transactionService;
 
     @Transactional
+    @LogDatasourceError(type="ERROR")
     public void createPaymentSchedule(Long accountId, BigDecimal loanAmount,
                                       BigDecimal annualInterestRate, Integer months) {
         AccountDTO account = accountService.getAccountById(accountId);

--- a/account_processing/src/main/java/org/accountpr/demo/service/PaymentService.java
+++ b/account_processing/src/main/java/org/accountpr/demo/service/PaymentService.java
@@ -4,6 +4,7 @@ import org.accountpr.demo.model.*;
 import org.accountpr.demo.model.dto.PaymentDTO;
 import org.accountpr.demo.model.enums.PaymentType;
 import org.accountpr.demo.repository.PaymentRepository;
+import org.aop.annotations.LogDatasourceError;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,7 +18,7 @@ import java.util.stream.Collectors;
 public class PaymentService {
 
     private final PaymentRepository paymentRepository;
-
+    @LogDatasourceError(type = "ERROR")
     public PaymentDTO createPayment(PaymentDTO dto) {
         Payment payment = Payment.builder(
                 dto.getAccountId(),
@@ -62,7 +63,7 @@ public class PaymentService {
                 .map(this::convertToDTO)
                 .collect(Collectors.toList());
     }
-
+    @LogDatasourceError(type = "ERROR")
     public PaymentDTO updatePayment(Long id, PaymentDTO dto) {
         Payment payment = paymentRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Payment not found with id: " + id));
@@ -79,6 +80,7 @@ public class PaymentService {
         return convertToDTO(updated);
     }
 
+    @LogDatasourceError(type = "WARN")
     public void deletePayment(Long id) {
         if (!paymentRepository.existsById(id)) {
             throw new IllegalArgumentException("Payment not found with id: " + id);

--- a/account_processing/src/main/java/org/accountpr/demo/service/TransactionMonitoringService.java
+++ b/account_processing/src/main/java/org/accountpr/demo/service/TransactionMonitoringService.java
@@ -11,6 +11,7 @@ import org.accountpr.demo.model.enums.AccountStatus;
 import org.accountpr.demo.model.enums.CardStatus;
 import org.accountpr.demo.model.enums.TransactionType;
 import org.accountpr.demo.repository.CardTransactionMonitoringRepository;
+import org.aop.annotations.LogDatasourceError;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -42,6 +43,7 @@ public class TransactionMonitoringService {
     private int cleanupHours;
 
     @Transactional
+    @LogDatasourceError(type = "ERROR")
     public boolean checkTransactionLimit(Long cardId, TransactionType transactionType, BigDecimal amount) {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime windowStart = now.minusMinutes(timeWindowMinutes);

--- a/account_processing/src/main/java/org/accountpr/demo/service/TransactionService.java
+++ b/account_processing/src/main/java/org/accountpr/demo/service/TransactionService.java
@@ -5,6 +5,7 @@ import org.accountpr.demo.model.enums.TransactionStatus;
 import org.accountpr.demo.model.enums.TransactionType;
 import org.accountpr.demo.repository.TransactionRepository;
 import org.accountpr.demo.model.dto.TransactionDTO;
+import org.aop.annotations.LogDatasourceError;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +20,7 @@ public class TransactionService {
 
     private final TransactionRepository transactionRepository;
 
+    @LogDatasourceError(type = "ERROR")
     public TransactionDTO createTransaction(TransactionDTO dto) {
         Transaction transaction = Transaction.builder(
                 dto.getAccountId(),
@@ -69,6 +71,7 @@ public class TransactionService {
                 .collect(Collectors.toList());
     }
 
+    @LogDatasourceError(type = "ERROR")
     public TransactionDTO updateTransaction(Long id, TransactionDTO dto) {
         Transaction transaction = transactionRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Transaction not found with id: " + id));
@@ -84,6 +87,7 @@ public class TransactionService {
         return convertToDTO(updated);
     }
 
+    @LogDatasourceError(type = "ERROR")
     public void deleteTransaction(Long id) {
         if (!transactionRepository.existsById(id)) {
             throw new IllegalArgumentException("Transaction not found with id: " + id);

--- a/account_processing/src/main/resources/application.yml
+++ b/account_processing/src/main/resources/application.yml
@@ -69,3 +69,9 @@ credit:
   payment:
     check-interval-hours: 24    #check expired payments one per day
     grace-period-days: 5
+aop:
+  metric:
+    execution-time-limit: 2000
+  cache:
+    default-ttl: 300000
+    cleanup-interval: 60000

--- a/account_processing/src/main/resources/application.yml
+++ b/account_processing/src/main/resources/application.yml
@@ -45,16 +45,20 @@ spring:
 
 logging:
   level:
-    org.hibernate.SQL: DEBUG
-    org.springframework.kafka: DEBUG
-    org.springframework.web: DEBUG
-    org.accountpr.demo: DEBUG
-
+    #org.hibernate.SQL: DEBUG
+    #org.springframework.kafka: DEBUG
+    org.aop: DEBUG
+    org.springframework.aop: DEBUG
+    org.springframework.context: DEBUG
+    org.springframework.boot: DEBUG
+    #org.springframework.web: DEBUG
+    #org.accountpr.demo: DEBUG
 kafka:
   topics:
     client-products: client_products
     client-cards: client_cards
     client-transactions: client_transactions
+    service-logs: service_logs
 transaction:
   limits:
     max-transactions-per-card: 10
@@ -63,5 +67,5 @@ transaction:
     cleanup-hours: 24
 credit:
   payment:
-    check-interval-hours: 24    # Проверка просроченных платежей раз в сутки
+    check-interval-hours: 24    #check expired payments one per day
     grace-period-days: 5

--- a/account_processing/src/main/resources/db/migration/V7__create_error_log_table.sql
+++ b/account_processing/src/main/resources/db/migration/V7__create_error_log_table.sql
@@ -1,0 +1,18 @@
+CREATE TABLE error_log (
+    id BIGSERIAL PRIMARY KEY,
+    microservice_name VARCHAR(100) NOT NULL,
+    timestamp TIMESTAMP NOT NULL,
+    method_signature TEXT NOT NULL,
+    exception_stack_trace TEXT,
+    exception_message TEXT,
+    method_parameters TEXT,
+    request_uri TEXT,
+    request_params TEXT,
+    request_body TEXT,
+    log_type VARCHAR(20) NOT NULL CHECK (log_type IN ('ERROR', 'WARNING', 'INFO')),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_error_log_timestamp ON error_log(timestamp);
+CREATE INDEX idx_error_log_microservice ON error_log(microservice_name);
+CREATE INDEX idx_error_log_type ON error_log(log_type);

--- a/aop_annotations/pom.xml
+++ b/aop_annotations/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>ru.t1hwork</groupId>
+        <artifactId>t1-homework</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+    <artifactId>aop_annotations</artifactId>
+    <packaging>jar</packaging>
+    <properties>
+        <maven.compiler.source>22</maven.compiler.source>
+        <maven.compiler.target>22</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+    </dependencies>
+   <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>repackage</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/aop_annotations/src/main/java/org/aop/annotations/Cached.java
+++ b/aop_annotations/src/main/java/org/aop/annotations/Cached.java
@@ -1,0 +1,13 @@
+package org.aop.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Cached {
+    String cacheName() default "";
+    long ttl() default 300000;
+}

--- a/aop_annotations/src/main/java/org/aop/annotations/HttpIncomeRequestLog.java
+++ b/aop_annotations/src/main/java/org/aop/annotations/HttpIncomeRequestLog.java
@@ -1,0 +1,11 @@
+package org.aop.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HttpIncomeRequestLog {
+}

--- a/aop_annotations/src/main/java/org/aop/annotations/HttpOutcomeRequestLog.java
+++ b/aop_annotations/src/main/java/org/aop/annotations/HttpOutcomeRequestLog.java
@@ -1,0 +1,11 @@
+package org.aop.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface HttpOutcomeRequestLog {
+}

--- a/aop_annotations/src/main/java/org/aop/annotations/LogDatasourceError.java
+++ b/aop_annotations/src/main/java/org/aop/annotations/LogDatasourceError.java
@@ -1,0 +1,12 @@
+package org.aop.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LogDatasourceError {
+String type() default "ERROR";
+}

--- a/aop_annotations/src/main/java/org/aop/annotations/Metric.java
+++ b/aop_annotations/src/main/java/org/aop/annotations/Metric.java
@@ -1,0 +1,12 @@
+package org.aop.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Metric {
+    String name() default "";
+}

--- a/aop_annotations/src/main/java/org/aop/aspect/CachedAspect.java
+++ b/aop_annotations/src/main/java/org/aop/aspect/CachedAspect.java
@@ -1,0 +1,94 @@
+package org.aop.aspect;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aop.annotations.Cached;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+
+@Slf4j
+@Aspect
+@Component
+public class CachedAspect {
+    private final Map<String, Map<Object, CacheEntry>> cacheStore= new ConcurrentHashMap<>();
+    private final ScheduledExecutorService cleanupScheduler= Executors.newScheduledThreadPool(1);
+    public CachedAspect(){
+        cleanupScheduler.scheduleAtFixedRate(this::cleanupExpiredEntries, 1,1, TimeUnit.MINUTES);
+    }
+
+    @Around("@annotation(cached)")
+    public Object cacheMethodResult(ProceedingJoinPoint joinPoint, Cached cached) throws Throwable{
+      String cacheName=getCacheName(joinPoint, cached);
+      Object cacheKey=generateCacheKey(joinPoint);
+      CacheEntry cachedResult= getFromCache(cacheName,cacheKey);
+      if (cachedResult!=null){
+          log.debug("Cache hit for {}.{}", cacheName,cacheKey);
+          return cachedResult.getData();
+      }
+      log.debug("Cache miss for {}.{}, executing method", cacheName, cacheKey);
+      Object result=joinPoint.proceed();
+      if(result!=null){
+          putToCache(cacheName,cacheKey,result,cached.ttl());
+      }
+      return result;
+    }
+    private String getCacheName(ProceedingJoinPoint joinPoint, Cached cached) {
+    if(!cached.cacheName().isEmpty()){return cached.cacheName();}
+    return joinPoint.getTarget().getClass().getSimpleName()+"."+joinPoint.getSignature().getName();
+    } private Object generateCacheKey(ProceedingJoinPoint joinPoint) {
+        Object[] args=joinPoint.getArgs();
+        if(args.length == 1){
+            Object arg=args[0];
+            if(arg instanceof Long || arg instanceof Integer || arg instanceof String){return arg;}
+            return arg.hashCode();
+        }
+        return Arrays.hashCode(args);
+    }
+    private CacheEntry getFromCache(String cacheName, Object key) {
+   Map<Object, CacheEntry> cache=cacheStore.get(cacheName);
+   if (cache==null){
+       return null;
+   }CacheEntry entry=cache.get(key);
+   if(entry!=null && !entry.isExpired()){
+       return entry;
+   }
+   if ((entry!=null)){
+       cache.remove(key);
+   }return null;
+    }
+    private void putToCache(String cacheName, Object key, Object data, long ttl) {
+    cacheStore.computeIfAbsent(cacheName, k-> new ConcurrentHashMap<>())
+            .put(key, new CacheEntry(data, System.currentTimeMillis()+ttl));
+    }
+    public void cleanupExpiredEntries(){
+        long now = System.currentTimeMillis();
+        cacheStore.forEach((cacheName, cache)->{
+            cache.entrySet().removeIf(entry->entry.getValue().isExpired(now));
+        });
+    }
+
+
+    @RequiredArgsConstructor
+private static class CacheEntry{
+        @Getter
+    private final Object data;
+    private final long expirationTime;
+        public boolean isExpired(){
+            return isExpired(System.currentTimeMillis());
+        }
+        public boolean isExpired(long currentTime) {
+            return currentTime > expirationTime;
+        }
+}}

--- a/aop_annotations/src/main/java/org/aop/aspect/HttpIncomeRequestLogAspect.java
+++ b/aop_annotations/src/main/java/org/aop/aspect/HttpIncomeRequestLogAspect.java
@@ -1,0 +1,83 @@
+package org.aop.aspect;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aop.annotations.HttpIncomeRequestLog;
+import org.aop.model.ErrorLog;
+import org.aop.model.dto.ErrorLogDTO;
+import org.aop.repository.ErrorLogRepository;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+@Aspect
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class HttpIncomeRequestLogAspect {
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final ErrorLogRepository errorLogRepository;
+    @Value("${spring.application.name}")
+    private String microserviceName;
+
+    @Before("@annotation(httpIncomeRequestLog)")
+    public void logHttpIncomeRequest(JoinPoint joinPoint, HttpIncomeRequestLog httpIncomeRequestLog){
+        try{
+            HttpServletRequest request=((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+            String uri=request.getRequestURI();
+            String params=request.getParameterMap().entrySet().stream()
+                    .map(entry->entry.getKey()+"="+ Arrays.toString(entry.getValue()))
+                    .collect(Collectors.joining(","));
+            String body=extractBody(joinPoint.getArgs());
+            ErrorLogDTO errorLogDTO= ErrorLogDTO.builder()
+                    .timestamp(new Timestamp(System.currentTimeMillis()))
+                    .methodSignature(joinPoint.getSignature().toShortString())
+                    .requestUri(uri)
+                    .requestParams(params)
+                    .requestBody(body)
+                    .build();
+            try{
+                var message= MessageBuilder
+                        .withPayload(errorLogDTO)
+                        .setHeader(KafkaHeaders.TOPIC, "service_logs")
+                        .setHeader(KafkaHeaders.KEY, microserviceName)
+                        .setHeader("type", "INFO")
+                        .build();
+                        kafkaTemplate.send(message);
+            }catch (Exception kafkaEx){
+                ErrorLog errorLog=ErrorLog.builder()  .microserviceName(microserviceName)
+                        .timestamp(errorLogDTO.getTimestamp())
+                        .methodSignature(errorLogDTO.getMethodSignature())
+                        .requestUri(errorLogDTO.getRequestUri())
+                        .requestParams(errorLogDTO.getRequestParams())
+                        .requestBody(errorLogDTO.getRequestBody())
+                        .logType("INFO").build();
+                errorLogRepository.save(errorLog);
+            }
+            log.info("🎯🎯🎯 HTTP INCOME to {}: {} {}🎯🎯🎯 ", microserviceName, uri, params);
+        }catch(Exception aspectEx){
+            log.error("🎯🎯🎯 Error in HttpIncomeRequestLogAspect: {}🎯🎯🎯 ", aspectEx.getMessage());
+        }
+    }
+
+    private String extractBody(Object[] args) {
+        for (Object arg:args){
+            if(arg!=null && !(arg instanceof String)){
+                return arg.toString();
+            }
+        }return null;
+    }
+
+}

--- a/aop_annotations/src/main/java/org/aop/aspect/HttpOutcomeRequestLogAspect.java
+++ b/aop_annotations/src/main/java/org/aop/aspect/HttpOutcomeRequestLogAspect.java
@@ -1,0 +1,86 @@
+package org.aop.aspect;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aop.annotations.HttpOutcomeRequestLog;
+import org.aop.model.ErrorLog;
+import org.aop.model.dto.ErrorLogDTO;
+import org.aop.repository.ErrorLogRepository;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+
+import java.sql.Timestamp;
+import java.util.Arrays;
+
+@Aspect
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class HttpOutcomeRequestLogAspect {
+    private final KafkaTemplate<String,Object> kafkaTemplate;
+    private final ErrorLogRepository errorLogRepository;
+    @Value("${spring.application.name}")
+    private String microserviceName;
+
+    @AfterReturning(pointcut = "@annotation(httpOutcomeRequestLog)", returning = "result")
+        public void logOutcomeRequest(JoinPoint joinPoint, HttpOutcomeRequestLog httpOutcomeRequestLog, Object result){
+       try{
+        String uri= extractUri(joinPoint.getArgs());
+        String params=extractParams(joinPoint.getArgs());
+        String body= extractBody(joinPoint.getArgs());
+
+        ErrorLogDTO errorLogDTO= ErrorLogDTO.builder()
+                .timestamp(new Timestamp(System.currentTimeMillis()))
+                .methodSignature(joinPoint.getSignature().toShortString())
+                .requestUri(uri)
+                .requestParams(params)
+                .requestBody(body)
+                .build();
+
+        try{
+            var message= MessageBuilder
+                    .withPayload(errorLogDTO)
+                    .setHeader(KafkaHeaders.TOPIC, "service_logs")
+                    .setHeader(KafkaHeaders.KEY, microserviceName)
+                    .setHeader("type", "INFO")
+                    .build();
+            kafkaTemplate.send(message);
+        }catch (Exception kafkaEx){
+            ErrorLog errorLog=ErrorLog.builder().microserviceName(microserviceName)
+                    .timestamp(errorLogDTO.getTimestamp())
+                    .methodSignature(errorLogDTO.getMethodSignature())
+                    .requestUri(errorLogDTO.getRequestUri())
+                    .requestParams(errorLogDTO.getRequestParams())
+                    .requestBody(errorLogDTO.getRequestBody())
+                    .logType("INFO").build();
+            errorLogRepository.save(errorLog);
+        }log.info("🎯🎯🎯 HTTP OUTCOME from {}: {} {}🎯🎯🎯 ", microserviceName, uri, params);
+       }catch (Exception aspectEx){
+           log.error("🎯🎯🎯 Error in HttpOutcomeRequestLogAspect: {}🎯🎯🎯 ", aspectEx.getMessage());
+       }
+    }
+
+       private String extractUri(Object[] args) {
+        for (Object arg: args){
+            if(arg instanceof String && ((String) arg).startsWith("http")){
+                return (String) arg;
+            }
+        }return "🎯🎯🎯 Unknown URI";
+    }
+    private String extractBody(Object[] args) {
+        return Arrays.toString(args);
+    }
+    private String extractParams(Object[] args) {
+        for (Object arg:args){
+            if (arg!=null && !(arg instanceof String)){
+                return arg.toString();
+            }
+        }return null;
+    }
+}

--- a/aop_annotations/src/main/java/org/aop/aspect/LogDatasourceErrorAspect.java
+++ b/aop_annotations/src/main/java/org/aop/aspect/LogDatasourceErrorAspect.java
@@ -1,0 +1,89 @@
+package org.aop.aspect;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aop.annotations.LogDatasourceError;
+import org.aop.model.ErrorLog;
+import org.aop.model.dto.ErrorLogDTO;
+import org.aop.repository.ErrorLogRepository;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+
+import java.sql.Timestamp;
+import java.util.Arrays;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class LogDatasourceErrorAspect {
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    private final ErrorLogRepository errorLogRepository;
+
+    @PostConstruct
+    public void init() {
+        log.info("🎯🎯🎯 LogDatasourceErrorAspect @PostConstruct INITIALIZED! 🎯🎯🎯");
+    }
+    @Value("${spring.application.name}")
+    private String microserviceName;
+    @AfterThrowing(pointcut = "@annotation(logAnnotation)", throwing = "ex")
+    public void logDatasourceError(JoinPoint joinPoint, LogDatasourceError logAnnotation, Exception ex) {
+        log.info("=== LogDatasourceErrorAspect INITIALIZED ===");
+        try {
+            ErrorLogDTO errorLogDTO = createErrorLogDTO(joinPoint, ex, null, null, null);
+            try {
+                var message = MessageBuilder
+                        .withPayload(errorLogDTO)
+                        .setHeader(KafkaHeaders.TOPIC, "service_logs")
+                        .setHeader(KafkaHeaders.KEY, microserviceName)
+                        .setHeader("type", logAnnotation.type())
+                        .build();
+                kafkaTemplate.send(message);
+                log.info("🎯🎯🎯 Error log sent to Kafka for method: {}🎯🎯🎯 ", joinPoint.getSignature());
+            } catch (Exception kafkaEx) {
+                ErrorLog errorLog = createErrorLog(errorLogDTO, logAnnotation.type());
+           errorLogRepository.save(errorLog);
+                log.warn("🎯🎯🎯 Kafka unavailable, error saved to DB: {}🎯🎯🎯 ", errorLog.getId());
+            }
+            log.error("🎯🎯🎯 DATASOURCE ERROR in {} - {}: {}🎯🎯🎯 ",
+                    microserviceName, joinPoint.getSignature(), ex.getMessage());
+        }catch (Exception aspectEx){
+            log.error("🎯🎯🎯 Error in LogDatasourceErrorAspect: {}🎯🎯🎯 ", aspectEx.getMessage());
+        }
+    }
+
+       private ErrorLogDTO createErrorLogDTO(JoinPoint joinPoint, Exception ex, String uri, String params, String body) {
+    return ErrorLogDTO.builder()
+            .timestamp(new Timestamp(System.currentTimeMillis()))
+            .methodSignature(joinPoint.getSignature().toShortString())
+            .exceptionStackTrace(Arrays.toString(ex.getStackTrace()))
+            .exceptionMessage(ex.getMessage())
+            .methodParameters(Arrays.toString(joinPoint.getArgs()))
+            .requestUri(uri)
+            .requestParams(params)
+            .requestBody(body)
+            .build();
+    }
+    private ErrorLog createErrorLog(ErrorLogDTO errorLogDTO, String logType) {
+    return ErrorLog.builder()
+            .microserviceName(microserviceName)
+            .timestamp(errorLogDTO.getTimestamp())
+            .methodSignature(errorLogDTO.getMethodSignature())
+            .exceptionStackTrace(errorLogDTO.getExceptionStackTrace())
+            .exceptionMessage(errorLogDTO.getExceptionMessage())
+            .methodParameters(errorLogDTO.getMethodParameters())
+            .requestUri(errorLogDTO.getRequestUri())
+            .requestParams(errorLogDTO.getRequestParams())
+            .requestBody(errorLogDTO.getRequestBody())
+            .logType(logType)
+            .build();
+    }
+
+}

--- a/aop_annotations/src/main/java/org/aop/aspect/MetricAspect.java
+++ b/aop_annotations/src/main/java/org/aop/aspect/MetricAspect.java
@@ -1,0 +1,67 @@
+package org.aop.aspect;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aop.annotations.Metric;
+import org.aop.model.dto.ErrorLogDTO;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+
+import java.sql.Timestamp;
+import java.util.Arrays;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class MetricAspect {
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+    @Value("${aop.metric.execution-time-limit:5000}")
+    private long executionTimeLimit;
+    @Value("${spring.application.name}")
+    private String microserviceName;
+    @Around("@annotation(metric)")
+public Object measureExecutionTime(ProceedingJoinPoint joinPoint, Metric metric)throws Throwable{
+
+        long startTime=System.currentTimeMillis();
+        try{
+            return joinPoint.proceed();
+        }finally {
+            long executionTime=System.currentTimeMillis()-startTime;
+            String methodName=metric.name().isEmpty()
+                    ? joinPoint.getSignature().toShortString() : metric.name();
+
+            log.debug("Method {} executed in {} ms", methodName, executionTime);
+        if(executionTime>executionTimeLimit){
+            sendSlowMethodWarning(joinPoint, methodName, executionTime);
+        }
+        }
+
+    }
+
+    private void sendSlowMethodWarning(ProceedingJoinPoint joinPoint, String methodName, long executionTime) {
+   try{
+       ErrorLogDTO errorLogDTO= ErrorLogDTO.builder()
+               .timestamp(new Timestamp(System.currentTimeMillis()))
+               .methodSignature(methodName)
+               .methodParameters(Arrays.toString(joinPoint.getArgs()))
+               .exceptionMessage("Method execution time exceeded limit: " + executionTime + " ms")
+               .build();
+       var message= MessageBuilder.withPayload(errorLogDTO)
+               .setHeader(KafkaHeaders.TOPIC, "service_logs")
+               .setHeader(KafkaHeaders.KEY, microserviceName)
+               .setHeader("type", "WARNING")
+               .build();
+       kafkaTemplate.send(message);
+   }catch (Exception e){
+       log.error("Failed to send metric warning to Kafka: {}", e.getMessage());
+   }
+
+    }
+}

--- a/aop_annotations/src/main/java/org/aop/model/ErrorLog.java
+++ b/aop_annotations/src/main/java/org/aop/model/ErrorLog.java
@@ -1,0 +1,54 @@
+package org.aop.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.sql.Timestamp;
+
+@Entity
+@Table(name="error_log")
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class ErrorLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String microserviceName;
+
+    @Column(nullable = false)
+    private Timestamp timestamp;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String methodSignature;
+
+    @Column(columnDefinition = "TEXT")
+    private String exceptionStackTrace;
+
+    @Column(columnDefinition = "TEXT")
+    private String exceptionMessage;
+
+    @Column(columnDefinition = "TEXT")
+    private String methodParameters;
+
+    @Column(columnDefinition = "TEXT")
+    private String requestUri;
+
+    @Column(columnDefinition = "TEXT")
+    private String requestParams;
+
+    @Column(columnDefinition = "TEXT")
+    private String requestBody;
+
+    @Column(nullable = false)
+    private String logType;
+
+    @Builder.Default
+    private Timestamp createdAt = new Timestamp(System.currentTimeMillis());
+}

--- a/aop_annotations/src/main/java/org/aop/model/dto/ErrorLogDTO.java
+++ b/aop_annotations/src/main/java/org/aop/model/dto/ErrorLogDTO.java
@@ -1,0 +1,23 @@
+package org.aop.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.sql.Timestamp;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ErrorLogDTO {
+    private Timestamp timestamp;
+    private String methodSignature;
+    private String exceptionStackTrace;
+    private String exceptionMessage;
+    private String methodParameters;
+    private String requestUri;
+    private String requestParams;
+    private String requestBody;
+}

--- a/aop_annotations/src/main/java/org/aop/repository/ErrorLogRepository.java
+++ b/aop_annotations/src/main/java/org/aop/repository/ErrorLogRepository.java
@@ -1,0 +1,9 @@
+package org.aop.repository;
+
+import org.aop.model.ErrorLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ErrorLogRepository extends JpaRepository<ErrorLog, Long> {
+}

--- a/client_processing/pom.xml
+++ b/client_processing/pom.xml
@@ -17,4 +17,11 @@
         <maven.compiler.target>22</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+    <dependencies> <dependency>
+        <groupId>ru.t1hwork</groupId>
+        <artifactId>aop_annotations</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+       <!-- <scope>system</scope>
+        <systemPath>${project.basedir}/../aop_annotations/target/aop_annotations-0.0.1-SNAPSHOT.jar</systemPath>-->
+    </dependency></dependencies>
 </project>

--- a/client_processing/src/main/java/org/clientpr/demo/ClientProcMain.java
+++ b/client_processing/src/main/java/org/clientpr/demo/ClientProcMain.java
@@ -2,8 +2,15 @@ package org.clientpr.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = {"org.clientpr.demo", "org.aop"})
+@EntityScan(basePackages = {"org.clientpr.demo", "org.aop.model"})
+@EnableJpaRepositories(basePackages = {"org.clientpr.demo", "org.aop.repository"})
+@EnableScheduling
+//@SpringBootApplication
 public class ClientProcMain {
     public static void main(String[] args) {
         SpringApplication.run(ClientProcMain.class, args);

--- a/client_processing/src/main/java/org/clientpr/demo/controller/BlacklistRegistryController.java
+++ b/client_processing/src/main/java/org/clientpr/demo/controller/BlacklistRegistryController.java
@@ -2,6 +2,7 @@ package org.clientpr.demo.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.aop.annotations.HttpIncomeRequestLog;
 import org.clientpr.demo.model.dto.BlacklistRegistryDTO;
 import org.clientpr.demo.model.enums.DocumentType;
 import org.clientpr.demo.service.BlacklistRegistryService;
@@ -16,6 +17,7 @@ import java.util.List;
 public class BlacklistRegistryController {
     private final BlacklistRegistryService blacklistRegistryService;
     @PostMapping
+    @HttpIncomeRequestLog
     public ResponseEntity<BlacklistRegistryDTO> addToBlacklist(@Valid @RequestBody BlacklistRegistryDTO blacklistDTO) {
         BlacklistRegistryDTO saved = blacklistRegistryService.addToBlacklist(blacklistDTO);
         return ResponseEntity.ok(saved);

--- a/client_processing/src/main/java/org/clientpr/demo/controller/CardRequestController.java
+++ b/client_processing/src/main/java/org/clientpr/demo/controller/CardRequestController.java
@@ -2,6 +2,7 @@ package org.clientpr.demo.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.aop.annotations.HttpIncomeRequestLog;
 import org.clientpr.demo.model.dto.CardCreationRequestDTO;
 import org.clientpr.demo.repository.ClientRepository;
 import org.clientpr.demo.service.ClientService;
@@ -21,6 +22,7 @@ public class CardRequestController {
     private final ClientRepository clientRepository;
 
     @PostMapping("/client/{clientId}/cards/request")
+    @HttpIncomeRequestLog
     public ResponseEntity<String> requestCardCreation(
             @PathVariable Long clientId,
             @Valid @RequestBody CardCreationRequestDTO cardRequest) {

--- a/client_processing/src/main/java/org/clientpr/demo/controller/ClientController.java
+++ b/client_processing/src/main/java/org/clientpr/demo/controller/ClientController.java
@@ -2,6 +2,7 @@ package org.clientpr.demo.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.aop.annotations.HttpIncomeRequestLog;
 import org.clientpr.demo.model.dto.ClientDTO;
 import org.clientpr.demo.model.enums.DocumentType;
 import org.clientpr.demo.service.ClientService;
@@ -18,49 +19,57 @@ public class ClientController {
     private final ClientService clientService;
 
     @PostMapping
+    @HttpIncomeRequestLog
     public ResponseEntity<ClientDTO> createClient(@Valid @RequestBody ClientDTO clientDTO) {
         ClientDTO createdClient = clientService.createClient(clientDTO);
         return ResponseEntity.ok(createdClient);
     }
 
     @GetMapping
+    @HttpIncomeRequestLog
     public ResponseEntity<List<ClientDTO>> getAllClients() {
         List<ClientDTO> clients = clientService.getAllClients();
         return ResponseEntity.ok(clients);
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<ClientDTO> getClientById(@PathVariable Long id) {
+    @HttpIncomeRequestLog
+        public ResponseEntity<ClientDTO> getClientById(@PathVariable Long id) {
         ClientDTO client = clientService.getClientById(id);
         return ResponseEntity.ok(client);
     }
 
     @GetMapping("/client-id/{clientId}")
-    public ResponseEntity<ClientDTO> getClientByClientId(@PathVariable String clientId) {
+    @HttpIncomeRequestLog
+        public ResponseEntity<ClientDTO> getClientByClientId(@PathVariable String clientId) {
         ClientDTO client = clientService.getClientByClientId(clientId);
         return ResponseEntity.ok(client);
     }
 
     @GetMapping("/user/{userId}")
-    public ResponseEntity<List<ClientDTO>> getClientsByUserId(@PathVariable Long userId) {
+    @HttpIncomeRequestLog
+        public ResponseEntity<List<ClientDTO>> getClientsByUserId(@PathVariable Long userId) {
         List<ClientDTO> clients = clientService.getClientsByUserId(userId);
         return ResponseEntity.ok(clients);
     }
 
     @GetMapping("/document-type/{documentType}")
-    public ResponseEntity<List<ClientDTO>> getClientsByDocumentType(@PathVariable DocumentType documentType) {
+    @HttpIncomeRequestLog
+        public ResponseEntity<List<ClientDTO>> getClientsByDocumentType(@PathVariable DocumentType documentType) {
         List<ClientDTO> clients = clientService.getClientsByDocumentType(documentType);
         return ResponseEntity.ok(clients);
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<ClientDTO> updateClient(@PathVariable Long id, @Valid @RequestBody ClientDTO clientDTO) {
+    @HttpIncomeRequestLog
+        public ResponseEntity<ClientDTO> updateClient(@PathVariable Long id, @Valid @RequestBody ClientDTO clientDTO) {
         ClientDTO updatedClient = clientService.updateClient(id, clientDTO);
         return ResponseEntity.ok(updatedClient);
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteClient(@PathVariable Long id) {
+    @HttpIncomeRequestLog
+        public ResponseEntity<Void> deleteClient(@PathVariable Long id) {
         clientService.deleteClient(id);
         return ResponseEntity.noContent().build();
     }

--- a/client_processing/src/main/java/org/clientpr/demo/controller/ClientProductController.java
+++ b/client_processing/src/main/java/org/clientpr/demo/controller/ClientProductController.java
@@ -2,6 +2,7 @@ package org.clientpr.demo.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.aop.annotations.HttpIncomeRequestLog;
 import org.clientpr.demo.model.dto.CardCreationRequestDTO;
 import org.clientpr.demo.model.dto.ClientProductDTO;
 import org.clientpr.demo.model.enums.ProductStatus;
@@ -22,6 +23,7 @@ public class ClientProductController {
 
     private final ClientProductService clientProductService;
     @PostMapping
+    @HttpIncomeRequestLog
     public ResponseEntity<ClientProductDTO> createClientProduct(@Valid @RequestBody ClientProductDTO clientProductDTO) {
         ClientProductDTO createdClientProduct = clientProductService.createClientProduct(clientProductDTO);
         return ResponseEntity.ok(createdClientProduct);

--- a/client_processing/src/main/java/org/clientpr/demo/controller/ProductController.java
+++ b/client_processing/src/main/java/org/clientpr/demo/controller/ProductController.java
@@ -2,6 +2,7 @@ package org.clientpr.demo.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.aop.annotations.HttpIncomeRequestLog;
 import org.clientpr.demo.model.dto.ProductDTO;
 import org.clientpr.demo.model.enums.ProductKey;
 import org.clientpr.demo.service.ProductService;
@@ -14,10 +15,9 @@ import java.util.List;
 @RequestMapping("/api/products")
 @RequiredArgsConstructor
 public class ProductController {
-
     private final ProductService productService;
-
     @PostMapping
+    @HttpIncomeRequestLog
     public ResponseEntity<ProductDTO> createProduct(@Valid @RequestBody ProductDTO productDTO) {
         ProductDTO createdProduct = productService.createProduct(productDTO);
         return ResponseEntity.ok(createdProduct);

--- a/client_processing/src/main/java/org/clientpr/demo/controller/TestAopController.java
+++ b/client_processing/src/main/java/org/clientpr/demo/controller/TestAopController.java
@@ -1,0 +1,19 @@
+package org.clientpr.demo.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class TestAopController {
+    @GetMapping("/test-aop")
+    @org.aop.annotations.HttpIncomeRequestLog
+    public String testAop() {
+        return "AOP Test";
+    }
+
+    @GetMapping("/test-error")
+    @org.aop.annotations.LogDatasourceError
+    public String testError() {
+        throw new RuntimeException("Test error for AOP");
+    }
+}

--- a/client_processing/src/main/java/org/clientpr/demo/controller/UserController.java
+++ b/client_processing/src/main/java/org/clientpr/demo/controller/UserController.java
@@ -2,6 +2,7 @@ package org.clientpr.demo.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.aop.annotations.HttpIncomeRequestLog;
 import org.clientpr.demo.model.dto.UserDTO;
 import org.clientpr.demo.service.UserService;
 import org.springframework.http.ResponseEntity;
@@ -13,10 +14,9 @@ import java.util.List;
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
 public class UserController {
-
     private final UserService userService;
-
     @PostMapping
+    @HttpIncomeRequestLog
     public ResponseEntity<UserDTO> createUser(@Valid @RequestBody UserDTO userDTO) {
         UserDTO createdUser = userService.createUser(userDTO);
         return ResponseEntity.ok(createdUser);

--- a/client_processing/src/main/java/org/clientpr/demo/repository/ClientRepository.java
+++ b/client_processing/src/main/java/org/clientpr/demo/repository/ClientRepository.java
@@ -1,5 +1,6 @@
 package org.clientpr.demo.repository;
 
+import org.aop.annotations.Cached;
 import org.clientpr.demo.model.Client;
 import org.clientpr.demo.model.enums.DocumentType;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,8 +11,11 @@ import java.util.Optional;
 
 @Repository
 public interface ClientRepository extends JpaRepository<Client, Long> {
+    @Cached(cacheName = "clients.byClientId", ttl = 600000)
     Optional<Client> findByClientId(String clientId);
+    @Cached
     List<Client> findByUserId(Long userId);
+    @Cached(cacheName = "clients.byDocumentType")
     List<Client> findByDocumentType(DocumentType documentType);
     boolean existsByClientId(String clientId);
     boolean existsByDocumentId(String documentId);

--- a/client_processing/src/main/java/org/clientpr/demo/service/ClientProductService.java
+++ b/client_processing/src/main/java/org/clientpr/demo/service/ClientProductService.java
@@ -1,6 +1,7 @@
 package org.clientpr.demo.service;
 
 import lombok.RequiredArgsConstructor;
+import org.aop.annotations.LogDatasourceError;
 import org.clientpr.demo.model.ClientProduct;
 import org.clientpr.demo.model.dto.ClientProductDTO;
 import org.clientpr.demo.model.dto.ProductDTO;
@@ -22,6 +23,7 @@ import java.util.stream.Collectors;
 public class ClientProductService {
     private final ClientProductRepository clientProductRepository;
     private final KafkaProducerService kafkaProducerService;
+    @LogDatasourceError(type = "ERROR")
     public ClientProductDTO createClientProduct(ClientProductDTO clientProductDTO) {
         if (clientProductRepository.existsByClientIdAndProductId(
                 clientProductDTO.getClientId(),

--- a/client_processing/src/main/java/org/clientpr/demo/service/ClientService.java
+++ b/client_processing/src/main/java/org/clientpr/demo/service/ClientService.java
@@ -2,6 +2,7 @@ package org.clientpr.demo.service;
 
 import lombok.RequiredArgsConstructor;
 import org.aop.annotations.LogDatasourceError;
+import org.aop.annotations.Metric;
 import org.clientpr.demo.model.Client;
 import org.clientpr.demo.model.dto.ClientDTO;
 import org.clientpr.demo.model.dto.UserDTO;
@@ -25,6 +26,7 @@ public class ClientService {
         return blacklistRegistryRepository.existsByDocumentTypeAndDocumentId(documentType, documentId);
     }
     @LogDatasourceError(type="ERROR")
+    @Metric
        public ClientDTO createClient(ClientDTO clientDTO) {
         if (clientRepository.existsByClientId(clientDTO.getClientId())) {
             throw new IllegalArgumentException("Client with this clientId already exists: " + clientDTO.getClientId());
@@ -51,33 +53,33 @@ public class ClientService {
 
         Client savedClient = clientRepository.save(client);
         return convertToDTO(savedClient);
-    }
+    }@Metric
     public List<ClientDTO> getAllClients() {
         return clientRepository.findAll()
                 .stream()
                 .map(this::convertToDTO)
                 .collect(Collectors.toList());
     }
-
+    @Metric(name="client.search.byId")
     public ClientDTO getClientById(Long id) {
         return clientRepository.findById(id)
                 .map(this::convertToDTO)
                 .orElseThrow(() -> new IllegalArgumentException("Client not found with id: " + id));
     }
-
+    @Metric(name="client.search.byClientId")
     public ClientDTO getClientByClientId(String clientId) {
         return clientRepository.findByClientId(clientId)
                 .map(this::convertToDTO)
                 .orElseThrow(() -> new IllegalArgumentException("Client not found with clientId: " + clientId));
     }
-
+    @Metric(name="client.search.byUserId")
     public List<ClientDTO> getClientsByUserId(Long userId) {
         return clientRepository.findByUserId(userId)
                 .stream()
                 .map(this::convertToDTO)
                 .collect(Collectors.toList());
     }
-
+    @Metric(name="client.search.byDocumentType")
     public List<ClientDTO> getClientsByDocumentType(DocumentType documentType) {
         return clientRepository.findByDocumentType(documentType)
                 .stream()

--- a/client_processing/src/main/java/org/clientpr/demo/service/ClientService.java
+++ b/client_processing/src/main/java/org/clientpr/demo/service/ClientService.java
@@ -1,6 +1,7 @@
 package org.clientpr.demo.service;
 
 import lombok.RequiredArgsConstructor;
+import org.aop.annotations.LogDatasourceError;
 import org.clientpr.demo.model.Client;
 import org.clientpr.demo.model.dto.ClientDTO;
 import org.clientpr.demo.model.dto.UserDTO;
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.stream.Collectors;
 
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -22,6 +24,7 @@ public class ClientService {
     private boolean isInBlaklist(DocumentType documentType, String documentId){
         return blacklistRegistryRepository.existsByDocumentTypeAndDocumentId(documentType, documentId);
     }
+    @LogDatasourceError(type="ERROR")
        public ClientDTO createClient(ClientDTO clientDTO) {
         if (clientRepository.existsByClientId(clientDTO.getClientId())) {
             throw new IllegalArgumentException("Client with this clientId already exists: " + clientDTO.getClientId());
@@ -81,7 +84,7 @@ public class ClientService {
                 .map(this::convertToDTO)
                 .collect(Collectors.toList());
     }
-
+    @LogDatasourceError(type = "ERROR")
     public ClientDTO updateClient(Long id, ClientDTO clientDTO) {
         Client existingClient = clientRepository.findById(id)
                 .orElseThrow(() -> new IllegalArgumentException("Client not found with id: " + id));
@@ -110,7 +113,7 @@ public class ClientService {
         Client updatedClient = clientRepository.save(existingClient);
         return convertToDTO(updatedClient);
     }
-
+    @LogDatasourceError(type = "WARNING")
     public void deleteClient(Long id) {
         if (!clientRepository.existsById(id)) {
             throw new IllegalArgumentException("Client not found with id: " + id);

--- a/client_processing/src/main/java/org/clientpr/demo/service/ProductService.java
+++ b/client_processing/src/main/java/org/clientpr/demo/service/ProductService.java
@@ -2,6 +2,7 @@ package org.clientpr.demo.service;
 
 
 import lombok.RequiredArgsConstructor;
+import org.aop.annotations.LogDatasourceError;
 import org.clientpr.demo.model.Product;
 import org.clientpr.demo.model.dto.ProductDTO;
 import org.clientpr.demo.model.enums.ProductKey;
@@ -19,6 +20,7 @@ import java.util.stream.Collectors;
 public class ProductService {
     private final ProductRepository productRepository;
 
+    @LogDatasourceError(type = "ERROR")
     public ProductDTO createProduct(ProductDTO productDTO) {
         Product product = Product.builder(
                 productDTO.getName(),

--- a/client_processing/src/main/java/org/clientpr/demo/service/UserService.java
+++ b/client_processing/src/main/java/org/clientpr/demo/service/UserService.java
@@ -1,6 +1,7 @@
 package org.clientpr.demo.service;
 
 import lombok.RequiredArgsConstructor;
+import org.aop.annotations.LogDatasourceError;
 import org.clientpr.demo.model.User;
 import org.clientpr.demo.model.dto.UserDTO;
 import org.clientpr.demo.repository.UserRepository;
@@ -16,6 +17,7 @@ import java.util.stream.Collectors;
 public class UserService {
     private final UserRepository userRepository;
 
+    @LogDatasourceError(type = "ERROR")
     public UserDTO createUser(UserDTO userDTO) {
         if (userRepository.existsByLogin(userDTO.getLogin())) {
             throw new IllegalArgumentException("Login already exists: " + userDTO.getLogin());

--- a/client_processing/src/main/resources/application.yml
+++ b/client_processing/src/main/resources/application.yml
@@ -37,10 +37,14 @@ spring:
 
 logging:
   level:
-    org.hibernate.SQL: DEBUG
-    org.hibernate.orm.jdbc.bind: TRACE
-    org.springframework.web: DEBUG
-    org.clientpr.demo: DEBUG
+     org.aop: DEBUG
+     org.springframework.aop: DEBUG
+     org.springframework.context: DEBUG
+     org.springframework.boot: DEBUG
+  #  org.hibernate.SQL: DEBUG
+   # org.hibernate.orm.jdbc.bind: TRACE
+    #org.springframework.web: DEBUG
+    #org.clientpr.demo: DEBUG
 
 kafka:
   topics:
@@ -48,6 +52,8 @@ kafka:
     client-credit-products: client_credit_products
     client-cards: client_cards
     client-transactions: client_transactions
+    service-logs: service_logs
+
 credit:
   default:
     interest-rate: 15.0

--- a/client_processing/src/main/resources/application.yml
+++ b/client_processing/src/main/resources/application.yml
@@ -59,3 +59,9 @@ credit:
     interest-rate: 15.0
     months: 24
     amount: 100000
+aop:
+  metric:
+    execution-time-limit: 2000
+  cache:
+    default-ttl: 300000
+    cleanup-interval: 60000

--- a/client_processing/src/main/resources/db/migration/V7__create_error_log_table.sql
+++ b/client_processing/src/main/resources/db/migration/V7__create_error_log_table.sql
@@ -1,0 +1,18 @@
+CREATE TABLE error_log (
+    id BIGSERIAL PRIMARY KEY,
+    microservice_name VARCHAR(100) NOT NULL,
+    timestamp TIMESTAMP NOT NULL,
+    method_signature TEXT NOT NULL,
+    exception_stack_trace TEXT,
+    exception_message TEXT,
+    method_parameters TEXT,
+    request_uri TEXT,
+    request_params TEXT,
+    request_body TEXT,
+    log_type VARCHAR(20) NOT NULL CHECK (log_type IN ('ERROR', 'WARNING', 'INFO')),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_error_log_timestamp ON error_log(timestamp);
+CREATE INDEX idx_error_log_microservice ON error_log(microservice_name);
+CREATE INDEX idx_error_log_type ON error_log(log_type);

--- a/credit_processing/pom.xml
+++ b/credit_processing/pom.xml
@@ -13,4 +13,11 @@
         <maven.compiler.target>22</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+    <dependencies> <dependency>
+        <groupId>ru.t1hwork</groupId>
+        <artifactId>aop_annotations</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+       <!-- <scope>system</scope>
+        <systemPath>${project.basedir}/../aop_annotations/target/aop_annotations-0.0.1-SNAPSHOT.jar</systemPath>-->
+    </dependency></dependencies>
 </project>

--- a/credit_processing/src/main/java/org/creditpr/demo/CreditProcMain.java
+++ b/credit_processing/src/main/java/org/creditpr/demo/CreditProcMain.java
@@ -2,8 +2,15 @@ package org.creditpr.demo;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
+@SpringBootApplication(scanBasePackages = {"org.creditpr.demo", "org.aop"})
+@EntityScan(basePackages = {"org.creditpr.demo", "org.aop.model"})
+@EnableJpaRepositories(basePackages = {"org.creditpr.demo", "org.aop.repository"})
+@EnableScheduling
+//@SpringBootApplication
 public class CreditProcMain {
     public static void main(String[] args) {
         SpringApplication.run(CreditProcMain.class, args);    }

--- a/credit_processing/src/main/java/org/creditpr/demo/config/KafkaProducerConfig.java
+++ b/credit_processing/src/main/java/org/creditpr/demo/config/KafkaProducerConfig.java
@@ -1,0 +1,30 @@
+package org.creditpr.demo.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+    @Bean
+    ProducerFactory<String, Object> producerFactory(){
+        Map<String, Object> configProps=new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "kafka:9092");
+    configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+    configProps.put(ProducerConfig.ACKS_CONFIG,"all");
+    return new DefaultKafkaProducerFactory<>(configProps);
+    }
+    @Bean
+    public KafkaTemplate<String,Object> kafkaTemplate(){
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/credit_processing/src/main/java/org/creditpr/demo/controller/PaymentRegistryController.java
+++ b/credit_processing/src/main/java/org/creditpr/demo/controller/PaymentRegistryController.java
@@ -2,6 +2,7 @@ package org.creditpr.demo.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.aop.annotations.HttpIncomeRequestLog;
 import org.creditpr.demo.dto.PaymentRegistryDTO;
 import org.creditpr.demo.service.PaymentRegistryService;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,7 @@ public class PaymentRegistryController {
     private final PaymentRegistryService service;
 
     @PostMapping
+    @HttpIncomeRequestLog
     public ResponseEntity<PaymentRegistryDTO> createPaymentRegistry(
             @Valid @RequestBody PaymentRegistryDTO dto) {
         PaymentRegistryDTO created = service.createPaymentRegistry(dto);
@@ -23,6 +25,7 @@ public class PaymentRegistryController {
     }
 
     @GetMapping("/{id}")
+    @HttpIncomeRequestLog
     public ResponseEntity<PaymentRegistryDTO> getPaymentRegistryById(@PathVariable Long id) {
         return service.getPaymentRegistryById(id)
                 .map(ResponseEntity::ok)
@@ -30,22 +33,26 @@ public class PaymentRegistryController {
     }
 
     @GetMapping
+    @HttpIncomeRequestLog
     public ResponseEntity<List<PaymentRegistryDTO>> getAllPaymentRegistries() {
         return ResponseEntity.ok(service.getAllPaymentRegistries());
     }
 
     @GetMapping("/product-registry/{productRegistryId}")
+    @HttpIncomeRequestLog
     public ResponseEntity<List<PaymentRegistryDTO>> getPaymentsByProductRegistryId(
             @PathVariable Long productRegistryId) {
         return ResponseEntity.ok(service.getPaymentRegistriesByProductRegistryId(productRegistryId));
     }
 
     @GetMapping("/expired")
+    @HttpIncomeRequestLog
     public ResponseEntity<List<PaymentRegistryDTO>> getExpiredPayments() {
         return ResponseEntity.ok(service.getExpiredPayments());
     }
 
     @PutMapping("/{id}")
+    @HttpIncomeRequestLog
     public ResponseEntity<PaymentRegistryDTO> updatePaymentRegistry(
             @PathVariable Long id,
             @Valid @RequestBody PaymentRegistryDTO dto) {
@@ -58,6 +65,7 @@ public class PaymentRegistryController {
     }
 
     @PatchMapping("/{id}/expired")
+    @HttpIncomeRequestLog
     public ResponseEntity<PaymentRegistryDTO> updatePaymentExpiredStatus(
             @PathVariable Long id,
             @RequestParam Boolean expired) {
@@ -70,6 +78,7 @@ public class PaymentRegistryController {
     }
 
     @DeleteMapping("/{id}")
+    @HttpIncomeRequestLog
     public ResponseEntity<Void> deletePaymentRegistry(@PathVariable Long id) {
         try {
             service.deletePaymentRegistry(id);

--- a/credit_processing/src/main/java/org/creditpr/demo/controller/ProductRegistryController.java
+++ b/credit_processing/src/main/java/org/creditpr/demo/controller/ProductRegistryController.java
@@ -2,6 +2,7 @@ package org.creditpr.demo.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.aop.annotations.HttpIncomeRequestLog;
 import org.creditpr.demo.dto.ProductRegistryDTO;
 import org.creditpr.demo.service.ProductRegistryService;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,7 @@ public class ProductRegistryController {
     private final ProductRegistryService service;
 
     @PostMapping
+    @HttpIncomeRequestLog
     public ResponseEntity<ProductRegistryDTO> createProductRegistry(
             @Valid @RequestBody ProductRegistryDTO dto) {
         ProductRegistryDTO created = service.createProductRegistry(dto);

--- a/credit_processing/src/main/java/org/creditpr/demo/repository/ProductRegistryRepository.java
+++ b/credit_processing/src/main/java/org/creditpr/demo/repository/ProductRegistryRepository.java
@@ -1,5 +1,6 @@
 package org.creditpr.demo.repository;
 
+import org.aop.annotations.Cached;
 import org.creditpr.demo.model.ProductRegistry;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -8,8 +9,11 @@ import java.util.Optional;
 
 @Repository
 public interface ProductRegistryRepository extends JpaRepository<ProductRegistry, Long> {
+    @Cached(ttl = 600000)
     List<ProductRegistry> findByClientId(Long clientId);
+   @Cached(cacheName = "productRegistry.byProductId")
     List<ProductRegistry> findByProductId(Long productId);
+    @Cached(cacheName = "productRegistry.byAccountId")
     Optional<ProductRegistry> findByAccountId(Long accountId);
     boolean existsByClientIdAndProductId(Long clientId, Long productId);
 }

--- a/credit_processing/src/main/java/org/creditpr/demo/service/ClientCreditProductConsumerService.java
+++ b/credit_processing/src/main/java/org/creditpr/demo/service/ClientCreditProductConsumerService.java
@@ -2,6 +2,8 @@ package org.creditpr.demo.service;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.aop.annotations.HttpIncomeRequestLog;
+import org.aop.annotations.HttpOutcomeRequestLog;
 import org.creditpr.demo.dto.PaymentRegistryDTO;
 import org.creditpr.demo.dto.ProductRegistryDTO;
 import org.springframework.beans.factory.annotation.Value;
@@ -82,6 +84,7 @@ public class ClientCreditProductConsumerService {
         }
     }
 
+    @HttpOutcomeRequestLog
     private Map<String, Object> getClientFromMC1(Long clientId) {
         try {
             String url = clientServiceUrl + "/api/clients/" + clientId;

--- a/credit_processing/src/main/java/org/creditpr/demo/service/PaymentRegistryService.java
+++ b/credit_processing/src/main/java/org/creditpr/demo/service/PaymentRegistryService.java
@@ -1,6 +1,7 @@
 package org.creditpr.demo.service;
 
 import lombok.RequiredArgsConstructor;
+import org.aop.annotations.LogDatasourceError;
 import org.creditpr.demo.dto.PaymentRegistryDTO;
 import org.creditpr.demo.model.PaymentRegistry;
 import org.creditpr.demo.repository.PaymentRegistryRepository;
@@ -17,6 +18,7 @@ import java.util.stream.Collectors;
 public class PaymentRegistryService {
     private final PaymentRegistryRepository repository;
 
+    @LogDatasourceError(type = "ERROR")
     public PaymentRegistryDTO createPaymentRegistry(PaymentRegistryDTO dto){
         PaymentRegistry paymentRegistry=PaymentRegistry.builder(
                 dto.getProductRegistryId(),

--- a/credit_processing/src/main/java/org/creditpr/demo/service/ProductRegistryService.java
+++ b/credit_processing/src/main/java/org/creditpr/demo/service/ProductRegistryService.java
@@ -2,6 +2,7 @@ package org.creditpr.demo.service;
 
 import lombok.RequiredArgsConstructor;
 import org.aop.annotations.LogDatasourceError;
+import org.aop.annotations.Metric;
 import org.creditpr.demo.dto.PaymentRegistryDTO;
 import org.creditpr.demo.dto.ProductRegistryDTO;
 import org.creditpr.demo.model.ProductRegistry;
@@ -20,6 +21,7 @@ public class ProductRegistryService {
     private final ProductRegistryRepository repository;
     private final PaymentRegistryService paymentRegistryService;
     @LogDatasourceError(type = "ERROR")
+    @Metric
     public ProductRegistryDTO createProductRegistry(ProductRegistryDTO dto){
         if(repository.existsByClientIdAndProductId(dto.getClientId(), dto.getProductId())){
             throw new IllegalArgumentException("Client already has this product");
@@ -40,13 +42,13 @@ public class ProductRegistryService {
     public Optional<ProductRegistryDTO> getProductRegistryById(Long id){
         return repository.findById(id).map(this::convertToDTO);
     }
-
+    @Metric
     public List<ProductRegistryDTO> getAllProductRegistries(){
         return repository.findAll().stream().map(this::convertToDTO).collect(Collectors.toList());
-    }
+    }@Metric(name="productRegistry.search.byClientId")
     public List<ProductRegistryDTO> getProductRegistriesByClientId(Long clientId){
         return repository.findByClientId(clientId).stream().map(this::convertToDTO).collect(Collectors.toList());
-    }
+    }@Metric(name="productRegistry.search.byProductId")
     public List<ProductRegistryDTO> getProductRegistriesByProductId(Long productId){
         return repository.findByProductId(productId).stream().map(this::convertToDTO).collect(Collectors.toList());
     }

--- a/credit_processing/src/main/java/org/creditpr/demo/service/ProductRegistryService.java
+++ b/credit_processing/src/main/java/org/creditpr/demo/service/ProductRegistryService.java
@@ -1,6 +1,7 @@
 package org.creditpr.demo.service;
 
 import lombok.RequiredArgsConstructor;
+import org.aop.annotations.LogDatasourceError;
 import org.creditpr.demo.dto.PaymentRegistryDTO;
 import org.creditpr.demo.dto.ProductRegistryDTO;
 import org.creditpr.demo.model.ProductRegistry;
@@ -18,6 +19,7 @@ import java.util.stream.Collectors;
 public class ProductRegistryService {
     private final ProductRegistryRepository repository;
     private final PaymentRegistryService paymentRegistryService;
+    @LogDatasourceError(type = "ERROR")
     public ProductRegistryDTO createProductRegistry(ProductRegistryDTO dto){
         if(repository.existsByClientIdAndProductId(dto.getClientId(), dto.getProductId())){
             throw new IllegalArgumentException("Client already has this product");

--- a/credit_processing/src/main/resources/application.yml
+++ b/credit_processing/src/main/resources/application.yml
@@ -24,6 +24,7 @@ spring:
         spring.json.value.default.type: java.util.Map
         spring.json.add.type.headers: false
         spring.json.use.type.headers: false
+
   datasource:
     url: jdbc:postgresql://${DB_HOST:postgres-credit}:${DB_PORT:5432}/${DB_NAME:credit_db}
     username: ${DB_USERNAME:postgres}
@@ -46,15 +47,20 @@ spring:
 
 logging:
   level:
-    org.hibernate.SQL: DEBUG
-    org.springframework.kafka: DEBUG
-    org.clientpr.demo.creditprocessing.service.KafkaConsumerService: DEBUG
-    org.springframework.web: DEBUG
-    org.creditpr.demo: DEBUG
+    org.aop: DEBUG
+    org.springframework.aop: DEBUG
+    org.springframework.context: DEBUG
+    org.springframework.boot: DEBUG
+    #org.hibernate.SQL: DEBUG
+    #org.springframework.kafka: DEBUG
+    #org.clientpr.demo.creditprocessing.service.KafkaConsumerService: DEBUG
+    #org.springframework.web: DEBUG
+    #org.creditpr.demo: DEBUG
 
 kafka:
   topics:
     client-credit-products: client_credit_products
+    service-logs: service_logs
 
 credit:
   limit: ${CREDIT_LIMIT:1000000}

--- a/credit_processing/src/main/resources/application.yml
+++ b/credit_processing/src/main/resources/application.yml
@@ -69,3 +69,9 @@ credit:
 client:
   service:
     url: ${CLIENT_SERVICE_URL:http://client-service:8080}
+aop:
+  metric:
+    execution-time-limit: 2000
+  cache:
+    default-ttl: 300000
+    cleanup-interval: 60000

--- a/credit_processing/src/main/resources/db/migration/V4__create_error_log_table.sql
+++ b/credit_processing/src/main/resources/db/migration/V4__create_error_log_table.sql
@@ -1,0 +1,18 @@
+CREATE TABLE error_log (
+    id BIGSERIAL PRIMARY KEY,
+    microservice_name VARCHAR(100) NOT NULL,
+    timestamp TIMESTAMP NOT NULL,
+    method_signature TEXT NOT NULL,
+    exception_stack_trace TEXT,
+    exception_message TEXT,
+    method_parameters TEXT,
+    request_uri TEXT,
+    request_params TEXT,
+    request_body TEXT,
+    log_type VARCHAR(20) NOT NULL CHECK (log_type IN ('ERROR', 'WARNING', 'INFO')),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_error_log_timestamp ON error_log(timestamp);
+CREATE INDEX idx_error_log_microservice ON error_log(microservice_name);
+CREATE INDEX idx_error_log_type ON error_log(log_type);

--- a/pom.xml
+++ b/pom.xml
@@ -22,10 +22,12 @@
 		<developer/>
 	</developers>
 	<modules>
+		<module>aop_annotations</module>
 		<module>client_processing</module>
 		<module>account_processing</module>
 		<module>credit_processing</module>
-    </modules>
+
+	</modules>
 	<scm>
 		<connection/>
 		<developerConnection/>
@@ -87,13 +89,7 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-test</artifactId>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
-
 	<build>
 		<plugins>
 			<plugin>


### PR DESCRIPTION
🎯 Feature Overview
Extended AOP system with two new annotations for performance monitoring and caching optimization across all microservices.

✨ New Annotations
@Metric - Tracks method execution time and sends warnings to Kafka when exceeding configured limits

@Cached - Automatic database query caching with TTL support and smart key generation
🔧 Technical Implementation
@Metric Aspect
Measures method execution time with nanosecond precision

Sends structured warnings to Kafka service_logs topic when execution exceeds aop.metric.execution-time-limit

Configurable per-method with custom names
Reuses existing ErrorLogDTO and Kafka infrastructure

@Cached Aspect
Automatic result caching for database queries

Smart cache key generation (primary keys for single params, hashCode for multiple)

Time-based eviction with configurable TTL

Background cleanup of expired entries

Thread-safe ConcurrentHashMap storage

⚙️ Configuration
yaml
aop:
  metric:
    execution-time-limit: 5000  
  cache:
    default-ttl: 300000        
🧪 Testing Instructions
Manual Testing
cmd
# Test performance monitoring
curl http://localhost:8081/api/clients/1

# Test caching (multiple requests)
curl http://localhost:8081/api/clients/1
curl http://localhost:8081/api/clients/1


Verification Steps
Check logs for cache hits/misses and execution times

Monitor Kafka UI (http://localhost:8080/) for performance warnings

Verify no impact on existing functionality

Test cache expiration with time delays